### PR TITLE
Fix Cmake accepts Python3 which gr-bluetooth doesn't support.

### DIFF
--- a/apps/btrx
+++ b/apps/btrx
@@ -28,9 +28,9 @@ class my_top_block(gr.top_block):
 						help="select Rx Antenna where appropriate")
 		parser.add_option("", "--samp-rate", type="eng_float", default=2e6,
 						help="set sample rate (bandwidth) [default=%default]")
-		parser.add_option("-f", "--freq", type="eng_float", default=None,
+		parser.add_option("-f", "--freq", type="eng_float", default=2.476e9,
 						help="set frequency to FREQ", metavar="FREQ")
-		parser.add_option("-g", "--gain", type="eng_float", default=None,
+		parser.add_option("-g", "--gain", type="eng_float", default=0.0,
 						help="set gain in dB (default is midpoint)")
 		parser.add_option("-N", "--nsamples", type="eng_float", default=None,
 						help="number of samples to collect [default=+inf]")
@@ -162,6 +162,7 @@ class my_top_block(gr.top_block):
 		self.connect(src, dst)
 
 if __name__ == '__main__':
+	#raw_input("Press return to continue...")
 	try:
 		my_top_block().run()
 	except KeyboardInterrupt:

--- a/cmake/Modules/GrSwig.cmake
+++ b/cmake/Modules/GrSwig.cmake
@@ -114,7 +114,7 @@ macro(GR_SWIG_MAKE name)
     endif()
 
     #append additional include directories
-    find_package(PythonLibs)
+    find_package(PythonLibs 2)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_PATH}) #deprecated name (now dirs)
     list(APPEND GR_SWIG_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
     list(APPEND GR_SWIG_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/multi_block.cc
+++ b/lib/multi_block.cc
@@ -192,13 +192,17 @@ namespace gr {
       if (ddci != d_channel_ddcs.end( )) {
         gr::filter::freq_xlating_fir_filter_ccf::sptr ddc = ddci->second;
         int ddc_samples = ninput_items - (ddc->history( ) - 1) - d_first_channel_sample;
+		// This changes how many iterations it takes to crash... Definitely on to something.
+		//printf("ddc_samples: %i\n", ddc_samples);
         gr_vector_const_void_star ddc_in( 1 );
         ddc_in[0] = &(((gr_complex *) in[0])[d_first_channel_sample]);
-        ddc_noutput_items = ddc->fixed_rate_ninput_to_noutput( ddc_samples );
+        ddc_noutput_items = ddc->fixed_rate_ninput_to_noutput( ddc_samples-695 ); // ddc_samples
+		//printf("ddc_noutput_items: %i\n", ddc_noutput_items);
         ddc_noutput_items = ddc->work( ddc_noutput_items, ddc_in, out );
-
+		//printf("after work %i\n", ddc_noutput_items);
         gr::blocks::complex_to_mag_squared::sptr mag2 = gr::blocks::complex_to_mag_squared::make( 1 );
-        float mag2_out[ddc_noutput_items];
+		//printf("past\n");
+        float *mag2_out = new float[ddc_noutput_items];
         gr_vector_void_star mag2_out_vector( 1 );
         mag2_out_vector[0] = &mag2_out[0];
         gr_vector_const_void_star ddc_out_const( 1 );
@@ -209,6 +213,7 @@ namespace gr {
           energy += mag2_out[i];
         }
         energy /= ddc_noutput_items;
+		delete [] mag2_out;
         //energy /= d_channel_filter_width;
       }
       else {

--- a/lib/multi_hopper_impl.cc
+++ b/lib/multi_hopper_impl.cc
@@ -81,7 +81,7 @@ namespace gr {
       int retval, latest_ac;
       uint32_t clkn; /* native (local) clock in 625 us */
       double freq;
-      char symbols[history()]; //poor estimate but safe
+      char symbols[history()+40]; //poor estimate but safe
 
       clkn = (int) (d_cumulative_count / d_samples_per_slot) & 0x7ffffff;
 

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
-find_package(PythonLibs)
+find_package(PythonLibs 2)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()
 endif()


### PR DESCRIPTION
Fixes https://github.com/greatscottgadgets/gr-bluetooth/issues/7 
Cmake accepts Python3 which gr-bluetooth doesn't support.
Based on GNU Radio commit 92b56aa8 to fix Bug #587 of gnuradio.
https://gnuradio.org/redmine/issues/587