### PR TITLE
Fixed segmentation fault in three modes of btrx.

### DIFF
--- a/lib/multi_LAP_impl.cc
+++ b/lib/multi_LAP_impl.cc
@@ -75,7 +75,7 @@ namespace gr {
 
 	for (freq = d_low_freq; freq <= d_high_freq; freq += 1e6)
 	{
-          gr_complex ch_samples[noutput_items];
+          gr_complex *ch_samples = new gr_complex[noutput_items+10000];
           gr_vector_void_star btch( 1 );
           btch[0] = ch_samples;
           double on_channel_energy, snr;
@@ -101,6 +101,7 @@ namespace gr {
               }
             }
           }
+          delete [] ch_samples;
 	}
 	d_cumulative_count += (int) d_samples_per_slot;
 

--- a/lib/multi_UAP_impl.cc
+++ b/lib/multi_UAP_impl.cc
@@ -78,7 +78,7 @@ namespace gr {
 
       for (freq = d_low_freq; freq <= d_high_freq; freq += 1e6)
 	{
-          gr_complex ch_samples[noutput_items];
+          gr_complex *ch_samples = new gr_complex[noutput_items+10000];
           gr_vector_void_star btch( 1 );
           btch[0] = ch_samples;
           double on_channel_energy, snr;
@@ -104,6 +104,7 @@ namespace gr {
               }
             }
           }
+          delete [] ch_samples;
 	}
       d_cumulative_count += (int) d_samples_per_slot;
 

--- a/lib/multi_block.cc
+++ b/lib/multi_block.cc
@@ -135,6 +135,7 @@ namespace gr {
 
       while ((oo < noutput_items) && (ii < ni)) {
         // produce output sample
+		//printf("d_mu %3.3f\n", d_mu);
         out[oo]       = d_interp->interpolate( &in[ii], d_mu );
         mm_val        = slice(d_last_sample) * out[oo] - slice(out[oo]) * d_last_sample;
         d_last_sample = out[oo];
@@ -184,7 +185,6 @@ namespace gr {
                                   int                        ninput_items )
     {
       int ddc_noutput_items       = 0;
-
       int classic_chan = abs_freq_channel( freq );
       std::map<int, gr::filter::freq_xlating_fir_filter_ccf::sptr>::const_iterator ddci = 
         d_channel_ddcs.find( classic_chan );
@@ -194,10 +194,13 @@ namespace gr {
         int ddc_samples = ninput_items - (ddc->history( ) - 1) - d_first_channel_sample;
 		// This changes how many iterations it takes to crash... Definitely on to something.
 		//printf("ddc_samples: %i\n", ddc_samples);
+		//printf("fcs: %i\n", d_first_channel_sample);
         gr_vector_const_void_star ddc_in( 1 );
         ddc_in[0] = &(((gr_complex *) in[0])[d_first_channel_sample]);
-        ddc_noutput_items = ddc->fixed_rate_ninput_to_noutput( ddc_samples-695 ); // ddc_samples
+        ddc_noutput_items = ddc->fixed_rate_ninput_to_noutput( ddc_samples ); // ddc_samples
 		//printf("ddc_noutput_items: %i\n", ddc_noutput_items);
+		//gr_vector_void_star ddc_out( 1 );
+		//ddc_out[0] = out[0];//malloc(100000);
         ddc_noutput_items = ddc->work( ddc_noutput_items, ddc_in, out );
 		//printf("after work %i\n", ddc_noutput_items);
         gr::blocks::complex_to_mag_squared::sptr mag2 = gr::blocks::complex_to_mag_squared::make( 1 );
@@ -214,6 +217,7 @@ namespace gr {
         }
         energy /= ddc_noutput_items;
 		delete [] mag2_out;
+		//free(ddc_out[0]);
         //energy /= d_channel_filter_width;
       }
       else {

--- a/lib/multi_sniffer_impl.cc
+++ b/lib/multi_sniffer_impl.cc
@@ -85,7 +85,7 @@ namespace gr {
                               gr_vector_void_star&       output_items )
     {
       for (double freq = d_low_freq; freq <= d_high_freq; freq += 1e6) {   
-        gr_complex *ch_samples = new gr_complex[noutput_items+100];
+        gr_complex *ch_samples = new gr_complex[noutput_items+100000];
         gr_vector_void_star btch( 1 );
         btch[0] = ch_samples;
         double on_channel_energy, snr;
@@ -135,6 +135,7 @@ namespace gr {
               int i = le_packet::sniff_aa(symp, limit, freq);
               if (i >= 0) {
                 int step = i + SYMBOLS_PER_LOW_ENERGY_PREAMBLE_AA;
+				//printf("symp[%i], len-i = %i\n", i, len-i);
                 aa(&symp[i], len - i, freq, snr);
                 len   -= step;
 				if(step >= sym_length) error_out("Bad step");

--- a/lib/packet_impl.cc
+++ b/lib/packet_impl.cc
@@ -1080,7 +1080,7 @@ namespace gr {
           d_packet_type = air_to_host8(&d_packet_header[3], 4);
           return true;
         } else {
-          printf("bad HEC! ");
+          printf("bad HEC! %02x %02x %i ", UAP, d_UAP, air_to_host8(&d_packet_header[3], 4));
         }
       }
 	
@@ -1531,10 +1531,10 @@ namespace gr {
     {
       d_index = freq2index( freq );
 
-      (void) ::memcpy( &d_link_symbols[0], stream, MAX_SYMBOLS );
+      (void) ::memcpy( &d_link_symbols[0], stream, LE_MAX_SYMBOLS );
 
       unsigned i, wi = INDICES[d_index];
-      for( i=40; i<MAX_SYMBOLS; i++, wi=(wi+1)%127 ) {
+      for( i=40; i<LE_MAX_SYMBOLS; i++, wi=(wi+1)%127 ) {
         d_link_symbols[i] ^= WHITENING_DATA[wi];
       }
 
@@ -1559,7 +1559,7 @@ namespace gr {
       }
 
       unsigned pi;
-      for( pi=0, i=56; i<MAX_SYMBOLS; pi++, i+=8 ) {
+      for( pi=0, i=56; i+8<LE_MAX_SYMBOLS; pi++, i+=8 ) {
         d_pdu[pi] = air_to_host8(&d_link_symbols[i], 8);
       }
     }


### PR DESCRIPTION
Still not sure about the LE_MAX_SYMBOLS, but at least we don't overflow the buffer.
Not sure why we need an extra 10k-100k samples in ch_samples, but we do, so I just go with it so it doesn't crash.
No guarantee that it does what it should but it doesn't crash anymore and I was able to capture a handful of packets from my phone and wireless headset.